### PR TITLE
Create Terratest suite for safe infrastructure assertions and cleanup (PLAN-185)

### DIFF
--- a/infra/src/index.ts
+++ b/infra/src/index.ts
@@ -140,6 +140,7 @@ export class TidelaneInfra {
     gcpCredentials: Secret,
     cloudflareToken: Secret,
     gcpProject: string,
+    cloudflareZoneId: string,
     @argument({ defaultValue: false }) preserveOnFailure: boolean,
   ): Promise<string> {
     return dag.container()
@@ -148,8 +149,10 @@ export class TidelaneInfra {
       .withSecretVariable("GOOGLE_CREDENTIALS", gcpCredentials)
       .withSecretVariable("CLOUDFLARE_API_TOKEN", cloudflareToken)
       .withEnvVariable("GCP_PROJECT", gcpProject)
+      .withEnvVariable("CLOUDFLARE_ZONE_ID", cloudflareZoneId)
       .withEnvVariable("PRESERVE_ON_FAILURE", preserveOnFailure ? "1" : "0")
       .withWorkdir("/workspace/test")
+      .withExec(["go", "mod", "tidy"])
       .withExec(["go", "test", "-v", "-timeout", "30m", "./..."])
       .stdout()
   }

--- a/infra/test/go.mod
+++ b/infra/test/go.mod
@@ -6,3 +6,6 @@ require (
 	github.com/gruntwork-io/terratest v0.46.7
 	github.com/stretchr/testify v1.9.0
 )
+
+// Run `go mod tidy` inside infra/test/ after cloning to generate go.sum.
+// The Dagger check function runs this automatically before go test.

--- a/infra/test/helpers_test.go
+++ b/infra/test/helpers_test.go
@@ -1,0 +1,23 @@
+package test
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+)
+
+// randomSuffix generates a 6-character lowercase hex string for use in
+// ephemeral resource names (e.g. "tidelane-test-a3f9c1").
+func randomSuffix() string {
+	b := make([]byte, 3)
+	if _, err := rand.Read(b); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(b)
+}
+
+// preserveOnFailure reports whether the caller has opted into keeping test
+// resources alive after a test failure for manual inspection.
+func preserveOnFailure() bool {
+	return os.Getenv("PRESERVE_ON_FAILURE") == "1"
+}

--- a/infra/test/infra_test.go
+++ b/infra/test/infra_test.go
@@ -1,38 +1,187 @@
 package test
 
 import (
-	"crypto/rand"
-	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// randomSuffix generates a 6-character hex suffix for ephemeral resource names.
-func randomSuffix() string {
-	b := make([]byte, 3)
-	if _, err := rand.Read(b); err != nil {
-		panic(err)
+// requiredEnv reads an environment variable and fails the test if absent.
+func requiredEnv(t *testing.T, key string) string {
+	t.Helper()
+	v := os.Getenv(key)
+	if v == "" {
+		t.Fatalf("required environment variable %s is not set", key)
 	}
-	return hex.EncodeToString(b)
+	return v
 }
 
-// preserveOnFailure checks whether the caller requested resource preservation.
-func preserveOnFailure() bool {
-	return os.Getenv("PRESERVE_ON_FAILURE") == "1"
+// tfOptions returns a base terraform.Options pointed at infra/terraform.
+// instanceName is set so test runs use an ephemeral name.
+func tfOptions(t *testing.T, instanceName string) *terraform.Options {
+	t.Helper()
+
+	gcpProject := requiredEnv(t, "GCP_PROJECT")
+	cfZoneID := requiredEnv(t, "CLOUDFLARE_ZONE_ID")
+
+	return terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../terraform",
+		Vars: map[string]interface{}{
+			"gcp_project_id":      gcpProject,
+			"instance_name":       instanceName,
+			"machine_type":        "e2-micro",
+			"cloudflare_zone_id":  cfZoneID,
+			"env":                 "test",
+		},
+		// Secrets come in via environment variables; Terraform reads
+		// GOOGLE_CREDENTIALS and CLOUDFLARE_API_TOKEN from the environment.
+		// TF_VAR_ssh_public_key is injected by the Dagger check function.
+		NoColor: true,
+	})
 }
 
-// TestGCEInstancePlan validates that terraform plan produces a valid plan for
-// an ephemeral instance without applying it.
-//
-// TODO(PLAN-185): implement full Terratest suite
-func TestGCEInstancePlan(t *testing.T) {
-	t.Skip("not yet implemented — placeholder for PLAN-185")
+// TestTerraformValidate runs `terraform validate` — no credentials required.
+// This is the cheapest gate: catches syntax errors and missing variable
+// declarations before any network calls.
+func TestTerraformValidate(t *testing.T) {
+	t.Parallel()
+
+	opts := &terraform.Options{
+		TerraformDir: "../terraform",
+		NoColor:      true,
+	}
+
+	terraform.InitAndValidate(t, opts)
+}
+
+// TestTerraformPlan runs a full plan against an ephemeral instance name and
+// asserts the plan JSON contains the expected resource types.
+// Requires GOOGLE_CREDENTIALS, CLOUDFLARE_API_TOKEN, GCP_PROJECT, CLOUDFLARE_ZONE_ID.
+// Does NOT create any real infrastructure.
+func TestTerraformPlan(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping plan test in short mode")
+	}
 
 	suffix := randomSuffix()
 	instanceName := "tidelane-test-" + suffix
-	t.Logf("ephemeral instance name: %s", instanceName)
+	t.Logf("ephemeral instance name for plan: %s", instanceName)
 
-	if preserveOnFailure() {
-		t.Log("PRESERVE_ON_FAILURE=1: test resources will be kept if this run fails")
+	opts := tfOptions(t, instanceName)
+	// InitAndPlanAndShowWithStructNoLogTempPlanFile avoids leaving plan files on disk.
+	planStruct := terraform.InitAndPlanAndShowWithStructNoLogTempPlanFile(t, opts)
+
+	// Assert expected resource types appear in the plan.
+	resourceTypes := planResourceTypes(planStruct)
+	assert.Contains(t, resourceTypes, "google_compute_instance",
+		"plan should include a GCE instance")
+	assert.Contains(t, resourceTypes, "google_compute_firewall",
+		"plan should include firewall rules")
+	assert.Contains(t, resourceTypes, "cloudflare_record",
+		"plan should include Cloudflare DNS records")
+	assert.Contains(t, resourceTypes, "cloudflare_zone_settings_override",
+		"plan should include Cloudflare zone TLS settings")
+
+	// Assert Cloudflare record names (apex and wildcard) without creating real DNS.
+	records := planCloudflareRecordNames(planStruct)
+	assert.Contains(t, records, "@", "plan should include apex A record")
+	assert.Contains(t, records, "*", "plan should include wildcard A record")
+}
+
+// TestGCEInstanceApply creates a real ephemeral GCE instance, asserts on outputs,
+// then destroys it. This is the full mutating check path.
+// Skipped with -short. Requires all credentials and a real GCP project.
+func TestGCEInstanceApply(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping apply test in short mode")
 	}
+
+	suffix := randomSuffix()
+	instanceName := "tidelane-test-" + suffix
+	t.Logf("provisioning ephemeral instance: %s", instanceName)
+
+	opts := tfOptions(t, instanceName)
+
+	// Teardown: always destroy unless PRESERVE_ON_FAILURE=1 and the test failed.
+	defer func() {
+		if t.Failed() && preserveOnFailure() {
+			t.Logf("PRESERVE_ON_FAILURE=1: skipping destroy. Clean up manually:")
+			t.Logf("  cd infra/terraform && terraform destroy -var=instance_name=%s", instanceName)
+			return
+		}
+		terraform.Destroy(t, opts)
+	}()
+
+	terraform.InitAndApply(t, opts)
+
+	// --- Output assertions ---
+
+	ipv4 := terraform.Output(t, opts, "instance_ipv4")
+	require.NotEmpty(t, ipv4, "instance_ipv4 output must not be empty")
+	t.Logf("instance_ipv4: %s", ipv4)
+
+	name := terraform.Output(t, opts, "instance_name")
+	assert.Equal(t, instanceName, name, "instance_name output must match the provisioned name")
+
+	zone := terraform.Output(t, opts, "instance_zone")
+	require.NotEmpty(t, zone, "instance_zone output must not be empty")
+
+	sshUser := terraform.Output(t, opts, "ssh_user")
+	assert.Equal(t, "smallweb", sshUser)
+
+	sshConn := terraform.Output(t, opts, "ssh_connection")
+	assert.Equal(t, fmt.Sprintf("smallweb@%s", ipv4), sshConn,
+		"ssh_connection should be user@ipv4")
+
+	selfLink := terraform.Output(t, opts, "instance_self_link")
+	assert.True(t, strings.HasPrefix(selfLink, "https://www.googleapis.com/compute/"),
+		"instance_self_link should be a GCE API URL")
+}
+
+// planResourceTypes extracts the set of resource type strings from a plan struct.
+func planResourceTypes(plan *terraform.PlanStruct) []string {
+	seen := map[string]bool{}
+	var types []string
+	for _, change := range plan.ResourceChangesMap {
+		if !seen[change.Type] {
+			seen[change.Type] = true
+			types = append(types, change.Type)
+		}
+	}
+	return types
+}
+
+// planCloudflareRecordNames returns the `name` field values of all
+// cloudflare_record resources in the plan, without creating any real DNS records.
+func planCloudflareRecordNames(plan *terraform.PlanStruct) []string {
+	var names []string
+	for _, change := range plan.ResourceChangesMap {
+		if change.Type != "cloudflare_record" {
+			continue
+		}
+		after, ok := change.Change.After.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, ok := after["name"].(string); ok {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// planJSON is used by TestTerraformPlanJSON to do raw JSON assertions.
+// Kept as a reference for ad-hoc debugging; not called by default.
+func planJSON(t *testing.T, opts *terraform.Options) map[string]interface{} {
+	t.Helper()
+	raw := terraform.InitAndPlanAndShow(t, opts)
+	var out map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(raw), &out))
+	return out
 }


### PR DESCRIPTION
## Summary
- Adds TestTerraformValidate (no creds required), TestTerraformPlan (offline assertions)
- Adds TestGCEInstanceApply (full apply/destroy with PRESERVE_ON_FAILURE support)
- Helpers: randomSuffix(), preserveOnFailure()

Closes PLAN-185.