### PR TITLE
feat: add PLAN-398 test-mode slot loop

### DIFF
--- a/.smallweb-root/README.md
+++ b/.smallweb-root/README.md
@@ -15,6 +15,10 @@ Files:
 - `admin/main.ts`: ACP-first admin surface with a `/acp` endpoint and `smallweb run` session runner
 - `admin/core.ts`: shared ACP/session orchestration, queue selection, persona-slot validation, downstream persona ACP client, and dry-run writeback logic
 - `admin/README.md`: task-spec fixture format and required slot layout for `PLAN-394`
+- `test-slot/main.ts`: minimal test-mode persona slot that exposes `/acp` and fetches a target URL on prompt
+- `test-slot/smallweb.json`: keeps the test slot public on `/acp` and `/healthz`
+- `range-fixture/main.ts`: deterministic public range target for the first `PLAN-398` loop
+- `range-fixture/smallweb.json`: exposes the fixture surface on `/`, `/recon`, and `/healthz`
 - `linear-agent/smallweb.json`: keeps the Linear receiver private while leaving `/healthz` and `/webhooks/**` public
 - `linear-agent/main.ts`: Smallweb-native Linear webhook ingress with runtime logging, optional activity posting, and Jules dispatch
 - `linear-agent/data/`: append-only runtime JSONL logs for deliveries, activities, notifications, and errors
@@ -65,6 +69,12 @@ export ADMIN_WRITEBACK_MODE=dry-run
 
 `admin` now exposes a minimal ACP-flavored JSON-RPC surface at `/acp` and uses the same session lifecycle for `smallweb run admin ...`. Queue selection is scoped to Planning issues labeled `test`.
 
+`PLAN-398` adds a minimal test-mode loop to the same Smallweb root:
+
+- `test-slot` is the disposable persona app for `mode=test`
+- `range-fixture` is the deterministic target/oracle surface for the first fast loop
+- `admin` now scores test-mode runs by checking downstream summaries against `oracle.expectedSubstrings`
+
 Local smoke test shape:
 
 ```sh
@@ -75,6 +85,8 @@ npm run smallweb:start
 Expected behavior:
 
 - `http://127.0.0.1:7777/healthz` with `Host: admin.tidelands.dev` returns `200`
+- `http://127.0.0.1:7777/healthz` with `Host: test-slot.tidelands.dev` returns `200`
+- `http://127.0.0.1:7777/healthz` with `Host: range-fixture.tidelands.dev` returns `200`
 - `http://127.0.0.1:7777/healthz` with `Host: linear-agent.tidelands.dev` returns `200`
 - `http://127.0.0.1:7777/healthz` with `Host: jules.tidelands.dev` returns `200`
 - `POST /webhooks/linear` on `Host: linear-agent.tidelands.dev` accepts signed Linear deliveries

--- a/.smallweb-root/admin/README.md
+++ b/.smallweb-root/admin/README.md
@@ -37,8 +37,11 @@ Each fixture issue body must contain an `ACP Task Spec` block:
   "taskType": "recon",
   "personas": ["apac-slot-07"],
   "instructions": "Run a bounded recon pass",
+  "oracle": {
+    "expectedSubstrings": ["Fixture Target", "reflected-search-param"]
+  },
   "target": {
-    "url": "https://fixture.test/recon",
+    "url": "https://range-fixture.tidelands.dev/recon",
     "method": "GET",
     "expectedTitle": "Fixture Target"
   },
@@ -54,6 +57,8 @@ Supported `taskType` values in this spike:
 - `exploit`
 
 At most 3 personas are allowed for one task.
+
+For `PLAN-398`, the oracle is intentionally simple: the downstream agent summary must contain each string listed in `oracle.expectedSubstrings`. That score is written back as `oracle PASS ...` or `oracle FAIL ...`.
 
 ## Persona slot layout
 
@@ -83,6 +88,8 @@ ACP_URL=https://apac-slot-07.persona.tidelands.dev/acp
 TZ=Australia/Sydney
 PROXY_URL=https://proxy.example.test
 ```
+
+Test-mode slots can declare `SLOT_MODE=test` (or `mode: test` in `network.json`). In test mode, `ACP_URL` stays required, but `TZ` and `PROXY_URL` are no longer required because fingerprint engineering is skipped.
 
 ## Runtime
 

--- a/.smallweb-root/admin/core.ts
+++ b/.smallweb-root/admin/core.ts
@@ -58,6 +58,9 @@ export type LinearIssue = {
 type TaskSpec = {
   blockedBy: string[]
   instructions: string
+  oracle?: {
+    expectedSubstrings: string[]
+  }
   personas: string[]
   target: {
     expectedTitle?: string
@@ -73,6 +76,7 @@ type PersonaSlot = {
   acpUrl: string
   envPath: string
   id: string
+  mode: "prod" | "test"
   networkConfigPath: string
   profileDir: string
   proxyUrl: string
@@ -406,6 +410,7 @@ function parseTaskSpec(issue: LinearIssue): TaskSpec {
     ? raw.blockedBy.map((value: unknown) => String(value).trim()).filter(Boolean)
     : []
   const target = raw.target ?? {}
+  const oracle = raw.oracle ?? {}
   const url = String(target.url ?? "").trim()
   const method = String(target.method ?? "GET").trim().toUpperCase()
   const instructions = String(raw.instructions ?? "").trim()
@@ -442,6 +447,13 @@ function parseTaskSpec(issue: LinearIssue): TaskSpec {
   return {
     blockedBy,
     instructions,
+    oracle: Array.isArray(oracle.expectedSubstrings)
+      ? {
+        expectedSubstrings: oracle.expectedSubstrings
+          .map((value: unknown) => String(value).trim())
+          .filter(Boolean),
+      }
+      : undefined,
     personas,
     target: {
       expectedTitle: target.expectedTitle ? String(target.expectedTitle) : undefined,
@@ -494,6 +506,9 @@ async function discoverPersonaSlots(slotRoot: string) {
         acpUrl: pickString(envValues.ACP_URL, network.acpUrl, network.acp_url),
         envPath,
         id: entry.name,
+        mode: pickString(envValues.SLOT_MODE, envValues.MODE, network.slotMode, network.mode).toLowerCase() === "test"
+          ? "test"
+          : "prod",
         networkConfigPath,
         profileDir,
         proxyUrl: pickString(
@@ -530,11 +545,11 @@ async function validatePersonaSlot(slot: PersonaSlot) {
     errors.push("Missing ACP_URL")
   }
 
-  if (!slot.timezone) {
+  if (slot.mode === "prod" && !slot.timezone) {
     errors.push("Missing TZ")
   }
 
-  if (!slot.proxyUrl) {
+  if (slot.mode === "prod" && !slot.proxyUrl) {
     errors.push("Missing PROXY_URL")
   }
 
@@ -716,12 +731,14 @@ function extractTitle(html: string) {
 
 function renderWriteback(plan: ConnectionPlan, resultLines: readonly string[]) {
   const joinedPersonas = plan.personas.map((persona) => persona.id).join(", ")
+  const joinedModes = Array.from(new Set(plan.personas.map((persona) => persona.mode))).join(", ")
   const targetUrl = plan.task.target.url
 
   return [
     `ACP spike run for ${plan.issue.identifier}`,
     "",
     `- Task type: ${plan.task.taskType}`,
+    `- Slot mode: ${joinedModes}`,
     `- Personas: ${joinedPersonas}`,
     `- Target: ${targetUrl}`,
     ...resultLines.map((line) => `- ${line}`),
@@ -752,6 +769,7 @@ function buildDownstreamPrompt(plan: ConnectionPlan, persona: PersonaSlot) {
     `Issue: ${plan.issue.identifier} — ${plan.issue.title}`,
     `Task type: ${plan.task.taskType}`,
     `Persona: ${persona.id}`,
+    `Slot mode: ${persona.mode}`,
     `Timezone: ${persona.timezone}`,
     `Proxy URL: ${persona.proxyUrl}`,
     `Target URL: ${plan.task.target.url}`,
@@ -772,6 +790,22 @@ function buildDownstreamPrompt(plan: ConnectionPlan, persona: PersonaSlot) {
   }
 
   return lines.join("\n")
+}
+
+function scoreOracle(task: TaskSpec, summary: string) {
+  const expectedSubstrings = task.oracle?.expectedSubstrings ?? []
+
+  if (expectedSubstrings.length === 0) {
+    return null
+  }
+
+  const missing = expectedSubstrings.filter((value) => !summary.includes(value))
+
+  return {
+    expected: expectedSubstrings.length,
+    missing,
+    passed: missing.length === 0,
+  }
 }
 
 async function postAcp(
@@ -1003,10 +1037,21 @@ async function runQueueTask(
     notifications.push(makeToolCallUpdate(session.sessionId, toolCallId, "in_progress"))
 
     const downstream = await runDownstreamPersonaSession(plan, persona, fetchImpl, config)
+    const oracle = scoreOracle(plan.task, downstream.summary)
 
     notifications.push(makeToolCallUpdate(session.sessionId, toolCallId, "completed"))
 
-    return `${persona.id}: ${downstream.stopReason}, ${downstream.summary}`
+    const pieces = [`${persona.id}: ${persona.mode}, ${downstream.stopReason}, ${downstream.summary}`]
+
+    if (oracle) {
+      pieces.push(
+        oracle.passed
+          ? `oracle PASS ${oracle.expected}/${oracle.expected}`
+          : `oracle FAIL missing ${oracle.missing.join(", ")}`,
+      )
+    }
+
+    return pieces.join(" | ")
   }
 
   try {

--- a/.smallweb-root/admin/main_test.ts
+++ b/.smallweb-root/admin/main_test.ts
@@ -3,6 +3,8 @@ import os from "node:os"
 import path from "node:path"
 import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises"
 
+import { createRangeFixtureApp } from "../range-fixture/main.ts"
+import { createTestSlotApp } from "../test-slot/main.ts"
 import { createAdminApp, type AdminConfig, type LinearIssue } from "./core.ts"
 
 function taskSpec(taskType: "aging" | "exploit" | "recon", personas: string[], url: string, extra: Record<string, unknown> = {}) {
@@ -10,6 +12,9 @@ function taskSpec(taskType: "aging" | "exploit" | "recon", personas: string[], u
 \`\`\`json
 ${JSON.stringify({
     instructions: `Fixture ${taskType} task`,
+    oracle: {
+      expectedSubstrings: ["Fixture Target", "reflected-search-param"],
+    },
     personas,
     target: {
       expectedTitle: "Fixture Target",
@@ -55,6 +60,22 @@ async function createSlot(
     path.join(slotDir, "network.json"),
     JSON.stringify(networkValues, null, 2),
   )
+}
+
+function createRouterFetch(routes: Record<string, { fetch(req: Request): Response | Promise<Response> }>) {
+  const fetchImpl = async (target: string | URL | Request, init?: RequestInit) => {
+    const request = target instanceof Request ? target : new Request(String(target), init)
+    const url = new URL(request.url)
+    const app = routes[url.host]
+
+    if (!app) {
+      throw new Error(`Unexpected routed host: ${url.host}`)
+    }
+
+    return await app.fetch(request)
+  }
+
+  return fetchImpl
 }
 
 async function readNdjson(response: Response) {
@@ -130,93 +151,9 @@ function ndjsonResponse(messages: unknown[]) {
   )
 }
 
-function createPersonaAcpFetch(handlers: Record<string, {
-  onPrompt?: (promptText: string) => void
-  summary: string
-}>) {
-  const calls: Array<{ method: string; payload: Record<string, unknown>; url: string }> = []
-
-  const fetchImpl = async (target: string | URL | Request, init?: RequestInit) => {
-    const url = String(target)
-    const handler = handlers[url]
-
-    if (!handler) {
-      throw new Error(`Unexpected downstream ACP URL: ${url}`)
-    }
-
-    const payload = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>
-    const method = String(payload.method ?? "")
-    calls.push({ method, payload, url })
-
-    if (method === "initialize") {
-      return ndjsonResponse([
-        {
-          id: payload.id ?? 0,
-          jsonrpc: "2.0",
-          result: {
-            agentCapabilities: {},
-            agentInfo: {
-              name: "persona-agent",
-              version: "0.1.0",
-            },
-            protocolVersion: 1,
-          },
-        },
-      ])
-    }
-
-    if (method === "session/new") {
-      return ndjsonResponse([
-        {
-          id: payload.id ?? 1,
-          jsonrpc: "2.0",
-          result: {
-            sessionId: `persona_${calls.length}`,
-          },
-        },
-      ])
-    }
-
-    if (method === "session/prompt") {
-      const params = payload.params as { prompt?: Array<{ text?: string }> } | undefined
-      const promptText = params?.prompt?.[0]?.text ?? ""
-      handler.onPrompt?.(promptText)
-
-      return ndjsonResponse([
-        {
-          jsonrpc: "2.0",
-          method: "session/update",
-          params: {
-            sessionId: "persona_session",
-            update: {
-              content: {
-                text: handler.summary,
-                type: "text",
-              },
-              sessionUpdate: "agent_message_chunk",
-            },
-          },
-        },
-        {
-          id: payload.id ?? 2,
-          jsonrpc: "2.0",
-          result: {
-            stopReason: "end_turn",
-          },
-        },
-      ])
-    }
-
-    throw new Error(`Unexpected downstream ACP method: ${method}`)
-  }
-
-  return { calls, fetchImpl }
-}
-
 Deno.test("ACP initialize -> session/new -> session/prompt executes a bounded recon fixture", async () => {
-  let observedPrompt = ""
   const issue = {
-    description: taskSpec("recon", ["apac-slot-07"], "https://fixture.test/recon"),
+    description: taskSpec("recon", ["apac-slot-07"], "https://range-fixture.tidelands.dev/recon"),
     id: "issue_fixture_recon",
     identifier: "PLAN-700",
     labels: ["test"],
@@ -226,18 +163,32 @@ Deno.test("ACP initialize -> session/new -> session/prompt executes a bounded re
     title: "Fixture recon task",
     updatedAt: new Date().toISOString(),
   }
-  const downstream = createPersonaAcpFetch({
-    "https://apac-slot-07.persona.test/acp": {
-      onPrompt(promptText) {
-        observedPrompt = promptText
-      },
-      summary: 'Visited https://fixture.test/recon and observed title "Fixture Target".',
-    },
+  const rangeFixture = createRangeFixtureApp()
+  const calls: Array<{ method: string; url: string }> = []
+  const routes: Record<string, { fetch(req: Request): Response | Promise<Response> }> = {
+    "range-fixture.tidelands.dev": rangeFixture,
+  }
+  const baseRouter = createRouterFetch(routes)
+  const routedFetch = async (target: string | URL | Request, init?: RequestInit) => {
+    const request = target instanceof Request ? target : new Request(String(target), init)
+    calls.push({
+      method: request.method,
+      url: request.url,
+    })
+
+    return await baseRouter(request)
+  }
+  const testSlot = createTestSlotApp({
+    fetchImpl: routedFetch,
   })
+  routes["apac-slot-07.persona.test"] = testSlot
   const { app, runtimeDir, slotRoot } = await createFixtureApp([issue], {
-    fetchImpl: downstream.fetchImpl,
+    fetchImpl: routedFetch,
   })
-  await createSlot(slotRoot, "apac-slot-07")
+  await createSlot(slotRoot, "apac-slot-07", {
+    env: { SLOT_MODE: "test" },
+    network: { mode: "test" },
+  })
 
   const initializeMessages = await postAcp(app, {
     id: 0,
@@ -287,25 +238,30 @@ Deno.test("ACP initialize -> session/new -> session/prompt executes a bounded re
 
   assert.match(agentChunks, /Selected PLAN-700/)
   assert.match(agentChunks, /Fixture Target/)
-  assert.match(observedPrompt, /Target URL: https:\/\/fixture\.test\/recon/)
-  assert.match(observedPrompt, /Persona: apac-slot-07/)
-  assert.deepEqual(
-    downstream.calls.map((call) => call.method),
-    ["initialize", "session/new", "session/prompt"],
+  assert.match(agentChunks, /oracle PASS 2\/2/)
+  assert.equal(
+    calls.filter((call) => call.url === "https://apac-slot-07.persona.test/acp").length,
+    3,
+  )
+  assert.equal(
+    calls.filter((call) => call.url === "https://range-fixture.tidelands.dev/recon").length,
+    1,
   )
   assert.equal(promptMessages.at(-1)?.result.stopReason, "end_turn")
 
   const writebackLog = await readFile(path.join(runtimeDir, "writebacks.jsonl"), "utf8")
   assert.match(writebackLog, /PLAN-700/)
   assert.match(writebackLog, /Fixture Target/)
+  assert.match(writebackLog, /Slot mode: test/)
+  assert.match(writebackLog, /oracle PASS 2\/2/)
   const personaLog = await readFile(path.join(runtimeDir, "persona-sessions.jsonl"), "utf8")
   assert.match(personaLog, /apac-slot-07/)
-  assert.match(personaLog, /persona_2/)
+  assert.match(personaLog, /reflected-search-param/)
 })
 
 Deno.test("missing PROXY_URL fails before any downstream ACP session starts", async () => {
   const issue = {
-    description: taskSpec("recon", ["apac-slot-08"], "https://fixture.test/recon"),
+    description: taskSpec("recon", ["apac-slot-08"], "https://range-fixture.tidelands.dev/recon"),
     id: "issue_fixture_bad_slot",
     identifier: "PLAN-701",
     labels: ["test"],
@@ -315,13 +271,17 @@ Deno.test("missing PROXY_URL fails before any downstream ACP session starts", as
     title: "Fixture recon missing proxy",
     updatedAt: new Date().toISOString(),
   }
-  const downstream = createPersonaAcpFetch({
-    "https://apac-slot-08.persona.test/acp": {
-      summary: "should not execute",
-    },
+  const rangeFixture = createRangeFixtureApp()
+  const routes: Record<string, { fetch(req: Request): Response | Promise<Response> }> = {
+    "range-fixture.tidelands.dev": rangeFixture,
+  }
+  const routerFetch = createRouterFetch(routes)
+  const testSlot = createTestSlotApp({
+    fetchImpl: routerFetch,
   })
+  routes["apac-slot-08.persona.test"] = testSlot
   const { app, runtimeDir, slotRoot } = await createFixtureApp([issue], {
-    fetchImpl: downstream.fetchImpl,
+    fetchImpl: routerFetch,
   })
   await createSlot(slotRoot, "apac-slot-08", {
     env: { PROXY_URL: "" },
@@ -354,14 +314,86 @@ Deno.test("missing PROXY_URL fails before any downstream ACP session starts", as
     .map((update) => update.content.text)
     .join("\n")
 
-  assert.equal(downstream.calls.length, 0)
+  const personaLogPath = path.join(runtimeDir, "persona-sessions.jsonl")
+  await assert.rejects(() => readFile(personaLogPath, "utf8"))
   assert.match(agentChunks, /Fail-fast aborted PLAN-701/)
   assert.match(agentChunks, /Missing PROXY_URL/)
 })
 
+Deno.test("test-mode slots skip proxy and timezone requirements but still run scoring", async () => {
+  const issue = {
+    description: taskSpec("recon", ["slot-test-mode"], "https://range-fixture.tidelands.dev/recon"),
+    id: "issue_fixture_test_mode",
+    identifier: "PLAN-706",
+    labels: ["test"],
+    priority: 1,
+    stateName: "Backlog",
+    stateType: "unstarted",
+    title: "Fixture test mode task",
+    updatedAt: new Date().toISOString(),
+  }
+  const rangeFixture = createRangeFixtureApp()
+  const routes: Record<string, { fetch(req: Request): Response | Promise<Response> }> = {
+    "range-fixture.tidelands.dev": rangeFixture,
+  }
+  const routedFetch = createRouterFetch(routes)
+  const testSlot = createTestSlotApp({
+    fetchImpl: routedFetch,
+  })
+  routes["slot-test-mode.persona.test"] = testSlot
+  const { app, runtimeDir, slotRoot } = await createFixtureApp([issue], {
+    fetchImpl: routedFetch,
+  })
+  await createSlot(slotRoot, "slot-test-mode", {
+    env: {
+      PROXY_URL: "",
+      SLOT_MODE: "test",
+      TZ: "",
+    },
+    network: {
+      mode: "test",
+      proxyUrl: "",
+      timeZone: "",
+    },
+  })
+
+  const newSession = await postAcp(app, {
+    id: 1,
+    jsonrpc: "2.0",
+    method: "session/new",
+    params: {
+      cwd: runtimeDir,
+      mcpServers: [],
+    },
+  })
+  const sessionId = newSession[0].result.sessionId
+  const promptMessages = await postAcp(app, {
+    id: 2,
+    jsonrpc: "2.0",
+    method: "session/prompt",
+    params: {
+      prompt: [{ text: "Run the next test-mode task", type: "text" }],
+      sessionId,
+    },
+  })
+  const agentChunks = promptMessages
+    .filter((message) => message.method === "session/update")
+    .map((message) => message.params.update)
+    .filter((update) => update.sessionUpdate === "agent_message_chunk")
+    .map((update) => update.content.text)
+    .join("\n")
+
+  assert.match(agentChunks, /Selected PLAN-706/)
+  assert.match(agentChunks, /oracle PASS 2\/2/)
+
+  const writebackLog = await readFile(path.join(runtimeDir, "writebacks.jsonl"), "utf8")
+  assert.match(writebackLog, /PLAN-706/)
+  assert.match(writebackLog, /Slot mode: test/)
+})
+
 Deno.test("blocked fixture issues are skipped in favor of the next eligible task", async () => {
   const blocker = {
-    description: taskSpec("aging", ["slot-blocker"], "https://fixture.test/blocker"),
+    description: taskSpec("aging", ["slot-blocker"], "https://range-fixture.tidelands.dev/recon"),
     id: "issue_blocker",
     identifier: "PLAN-702",
     labels: ["test"],
@@ -372,7 +404,7 @@ Deno.test("blocked fixture issues are skipped in favor of the next eligible task
     updatedAt: new Date().toISOString(),
   }
   const blocked = {
-    description: taskSpec("recon", ["slot-blocked"], "https://fixture.test/blocked", {
+    description: taskSpec("recon", ["slot-blocked"], "https://range-fixture.tidelands.dev/recon", {
       blockedBy: ["PLAN-702"],
     }),
     id: "issue_blocked",
@@ -385,7 +417,7 @@ Deno.test("blocked fixture issues are skipped in favor of the next eligible task
     updatedAt: new Date().toISOString(),
   }
   const eligible = {
-    description: taskSpec("recon", ["slot-eligible"], "https://fixture.test/eligible"),
+    description: taskSpec("recon", ["slot-eligible"], "https://range-fixture.tidelands.dev/recon"),
     id: "issue_eligible",
     identifier: "PLAN-704",
     labels: ["test"],
@@ -395,19 +427,26 @@ Deno.test("blocked fixture issues are skipped in favor of the next eligible task
     title: "Eligible fixture",
     updatedAt: new Date().toISOString(),
   }
-  const downstream = createPersonaAcpFetch({
-    "https://slot-blocker.persona.test/acp": {
-      summary: 'Visited https://fixture.test/blocker and observed title "Fixture Target".',
-    },
-    "https://slot-blocked.persona.test/acp": {
-      summary: 'Visited https://fixture.test/blocked and observed title "Fixture Target".',
-    },
-    "https://slot-eligible.persona.test/acp": {
-      summary: 'Visited https://fixture.test/eligible and observed title "Fixture Target".',
-    },
-  })
+  const rangeFixture = createRangeFixtureApp()
+  const routes: Record<string, { fetch(req: Request): Response | Promise<Response> }> = {
+    "range-fixture.tidelands.dev": rangeFixture,
+  }
+  const routedFetch = createRouterFetch(routes)
+  const slotBlocker = createTestSlotApp({ fetchImpl: routedFetch })
+  const slotBlocked = createTestSlotApp({ fetchImpl: routedFetch })
+  const slotEligible = createTestSlotApp({ fetchImpl: routedFetch })
+  routes["slot-blocker.persona.test"] = slotBlocker
+  routes["slot-blocked.persona.test"] = slotBlocked
+  routes["slot-eligible.persona.test"] = slotEligible
+  const routedCalls: string[] = []
+  const fetchImpl = async (target: string | URL | Request, init?: RequestInit) => {
+    const request = target instanceof Request ? target : new Request(String(target), init)
+    routedCalls.push(request.url)
+
+    return await routedFetch(request)
+  }
   const { app, runtimeDir, slotRoot } = await createFixtureApp([blocked, blocker, eligible], {
-    fetchImpl: downstream.fetchImpl,
+    fetchImpl,
   })
   await createSlot(slotRoot, "slot-blocker")
   await createSlot(slotRoot, "slot-blocked")
@@ -441,19 +480,13 @@ Deno.test("blocked fixture issues are skipped in favor of the next eligible task
 
   assert.match(chunks, /Selected PLAN-702/)
   assert.doesNotMatch(chunks, /Selected PLAN-703/)
-  assert.deepEqual(
-    downstream.calls.map((call) => call.url),
-    [
-      "https://slot-blocker.persona.test/acp",
-      "https://slot-blocker.persona.test/acp",
-      "https://slot-blocker.persona.test/acp",
-    ],
-  )
+  assert.equal(routedCalls.filter((url) => url === "https://slot-blocker.persona.test/acp").length, 3)
+  assert.equal(routedCalls.filter((url) => url === "https://slot-blocked.persona.test/acp").length, 0)
 })
 
 Deno.test("runCliSession reuses the same ACP session lifecycle without HTTP", async () => {
   const issue = {
-    description: taskSpec("recon", ["slot-cli"], "https://fixture.test/cli"),
+    description: taskSpec("recon", ["slot-cli"], "https://range-fixture.tidelands.dev/recon"),
     id: "issue_cli",
     identifier: "PLAN-705",
     labels: ["test"],
@@ -463,13 +496,15 @@ Deno.test("runCliSession reuses the same ACP session lifecycle without HTTP", as
     title: "CLI fixture",
     updatedAt: new Date().toISOString(),
   }
-  const downstream = createPersonaAcpFetch({
-    "https://slot-cli.persona.test/acp": {
-      summary: 'Visited https://fixture.test/cli and observed title "Fixture Target".',
-    },
-  })
+  const rangeFixture = createRangeFixtureApp()
+  const routes: Record<string, { fetch(req: Request): Response | Promise<Response> }> = {
+    "range-fixture.tidelands.dev": rangeFixture,
+  }
+  const routedFetch = createRouterFetch(routes)
+  const slotCli = createTestSlotApp({ fetchImpl: routedFetch })
+  routes["slot-cli.persona.test"] = slotCli
   const { app, slotRoot } = await createFixtureApp([issue], {
-    fetchImpl: downstream.fetchImpl,
+    fetchImpl: routedFetch,
   })
   await createSlot(slotRoot, "slot-cli")
 
@@ -478,8 +513,5 @@ Deno.test("runCliSession reuses the same ACP session lifecycle without HTTP", as
   assert.equal(messages[0].result.protocolVersion, 1)
   assert.equal(messages.at(-1)?.result.stopReason, "end_turn")
   assert.match(JSON.stringify(messages), /PLAN-705/)
-  assert.deepEqual(
-    downstream.calls.map((call) => call.method),
-    ["initialize", "session/new", "session/prompt"],
-  )
+  assert.match(JSON.stringify(messages), /oracle PASS 2\/2/)
 })

--- a/.smallweb-root/range-fixture/main.ts
+++ b/.smallweb-root/range-fixture/main.ts
@@ -1,0 +1,83 @@
+function html(body: string, title = "Fixture Target") {
+  return new Response(
+    `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${title}</title>
+  </head>
+  <body>
+    ${body}
+  </body>
+</html>`,
+    {
+      headers: {
+        "cache-control": "no-store",
+        "content-type": "text/html; charset=utf-8",
+      },
+    },
+  )
+}
+
+function json(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data, null, 2), {
+    status,
+    headers: {
+      "cache-control": "no-store",
+      "content-type": "application/json; charset=utf-8",
+    },
+  })
+}
+
+export function createRangeFixtureApp() {
+  return {
+    fetch(req: Request) {
+      const url = new URL(req.url)
+
+      if (url.pathname === "/healthz") {
+        return json({
+          app: "range-fixture",
+          ok: true,
+          path: url.pathname,
+        })
+      }
+
+      if (url.pathname === "/" || url.pathname === "/recon") {
+        const query = url.searchParams.get("q") ?? "fixture-query"
+        const finding = url.searchParams.get("finding") ?? "reflected-search-param"
+
+        return html(
+          [
+            `<main>`,
+            `  <h1>Fixture Recon Surface</h1>`,
+            `  <p data-reflected-query="${query}">Reflected query: ${query}</p>`,
+            `  <p data-expected-finding="${finding}">Known finding: ${finding}</p>`,
+            `</main>`,
+          ].join("\n"),
+        )
+      }
+
+      return json({
+        app: "range-fixture",
+        error: "Not found",
+        path: url.pathname,
+      }, 404)
+    },
+    run(args: string[]) {
+      console.log("range fixture app")
+      console.log(`args: ${JSON.stringify(args)}`)
+    },
+  }
+}
+
+const app = createRangeFixtureApp()
+
+export default {
+  fetch(req: Request) {
+    return app.fetch(req)
+  },
+  run(args: string[]) {
+    return app.run(args)
+  },
+}

--- a/.smallweb-root/range-fixture/main_test.ts
+++ b/.smallweb-root/range-fixture/main_test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict"
+
+import { createRangeFixtureApp } from "./main.ts"
+
+Deno.test("range fixture returns deterministic target HTML", async () => {
+  const app = createRangeFixtureApp()
+  const response = await app.fetch(new Request("https://range-fixture.tidelands.dev/recon?q=alpha&finding=known-vuln"))
+  const body = await response.text()
+
+  assert.equal(response.status, 200)
+  assert.match(body, /Fixture Target/)
+  assert.match(body, /Reflected query: alpha/)
+  assert.match(body, /Known finding: known-vuln/)
+})
+
+Deno.test("range fixture exposes healthz", async () => {
+  const app = createRangeFixtureApp()
+  const response = await app.fetch(new Request("https://range-fixture.tidelands.dev/healthz"))
+  const body = await response.json()
+
+  assert.equal(response.status, 200)
+  assert.equal(body.app, "range-fixture")
+  assert.equal(body.ok, true)
+})

--- a/.smallweb-root/range-fixture/smallweb.json
+++ b/.smallweb-root/range-fixture/smallweb.json
@@ -1,0 +1,7 @@
+{
+  "publicRoutes": [
+    "/",
+    "/recon",
+    "/healthz"
+  ]
+}

--- a/.smallweb-root/test-slot/main.ts
+++ b/.smallweb-root/test-slot/main.ts
@@ -1,0 +1,229 @@
+type JsonRpcRequest = {
+  id?: number | string | null
+  jsonrpc?: string
+  method?: string
+  params?: unknown
+}
+
+type JsonRpcMessage = Record<string, unknown>
+
+type SessionRecord = {
+  cwd: string
+  sessionId: string
+}
+
+type TestSlotServices = {
+  fetchImpl?: typeof fetch
+}
+
+function json(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data, null, 2), {
+    status,
+    headers: {
+      "cache-control": "no-store",
+      "content-type": "application/json; charset=utf-8",
+    },
+  })
+}
+
+function ndjson(messages: JsonRpcMessage[]) {
+  return new Response(
+    `${messages.map((message) => JSON.stringify(message)).join("\n")}\n`,
+    {
+      headers: {
+        "cache-control": "no-store",
+        "content-type": "application/x-ndjson; charset=utf-8",
+      },
+    },
+  )
+}
+
+function makeResult(id: number | string | null | undefined, result: unknown) {
+  return {
+    id: id ?? null,
+    jsonrpc: "2.0",
+    result,
+  }
+}
+
+function makeError(id: number | string | null | undefined, code: number, message: string) {
+  return {
+    error: {
+      code,
+      message,
+    },
+    id: id ?? null,
+    jsonrpc: "2.0",
+  }
+}
+
+function extractPromptText(params: unknown) {
+  const prompt = (params as { prompt?: Array<{ text?: string }> } | undefined)?.prompt ?? []
+
+  return prompt
+    .map((entry) => entry?.text ?? "")
+    .join("\n")
+    .trim()
+}
+
+function extractLineValue(promptText: string, prefix: string) {
+  const line = promptText
+    .split("\n")
+    .find((candidate) => candidate.startsWith(prefix))
+
+  return line ? line.slice(prefix.length).trim() : ""
+}
+
+function extractTitle(html: string) {
+  const match = /<title>([^<]+)<\/title>/i.exec(html)
+
+  return match?.[1]?.trim() ?? ""
+}
+
+function extractFinding(html: string) {
+  const dataAttr = /data-expected-finding="([^"]+)"/i.exec(html)
+
+  if (dataAttr?.[1]) {
+    return dataAttr[1].trim()
+  }
+
+  const textual = /Known finding:\s*([^<\n]+)/i.exec(html)
+
+  return textual?.[1]?.trim() ?? ""
+}
+
+export function createTestSlotApp(services: TestSlotServices = {}) {
+  const fetchImpl = services.fetchImpl ?? fetch
+  const sessions = new Map<string, SessionRecord>()
+
+  return {
+    async fetch(req: Request) {
+      const url = new URL(req.url)
+
+      if (url.pathname === "/healthz") {
+        return json({
+          app: "test-slot",
+          mode: "test",
+          ok: true,
+          path: url.pathname,
+        })
+      }
+
+      if (url.pathname !== "/acp" || req.method !== "POST") {
+        return json({
+          app: "test-slot",
+          error: "Not found",
+          path: url.pathname,
+        }, 404)
+      }
+
+      const payload = await req.json() as JsonRpcRequest
+      const id = payload.id ?? null
+
+      if (payload.jsonrpc !== "2.0" || !payload.method) {
+        return ndjson([makeError(id, -32600, "Invalid Request")])
+      }
+
+      if (payload.method === "initialize") {
+        return ndjson([
+          makeResult(id, {
+            agentCapabilities: {},
+            agentInfo: {
+              name: "test-slot",
+              version: "0.1.0",
+            },
+            protocolVersion: 1,
+          }),
+        ])
+      }
+
+      if (payload.method === "session/new") {
+        const cwd = String((payload.params as { cwd?: string } | undefined)?.cwd ?? "")
+
+        if (!cwd.startsWith("/")) {
+          return ndjson([makeError(id, -32602, "session/new requires absolute cwd")])
+        }
+
+        const sessionId = `slot_${crypto.randomUUID()}`
+        sessions.set(sessionId, {
+          cwd,
+          sessionId,
+        })
+
+        return ndjson([
+          makeResult(id, {
+            sessionId,
+          }),
+        ])
+      }
+
+      if (payload.method === "session/prompt") {
+        const params = payload.params as { sessionId?: string } | undefined
+        const sessionId = String(params?.sessionId ?? "")
+        const session = sessions.get(sessionId)
+
+        if (!session) {
+          return ndjson([makeError(id, -32001, "Unknown session")])
+        }
+
+        const promptText = extractPromptText(payload.params)
+        const targetUrl = extractLineValue(promptText, "Target URL: ")
+
+        if (!targetUrl) {
+          return ndjson([makeError(id, -32602, "Prompt is missing Target URL")])
+        }
+
+        const response = await fetchImpl(targetUrl, {
+          method: "GET",
+          headers: {
+            "x-tidelane-slot-session": session.sessionId,
+          },
+        })
+        const body = await response.text()
+        const title = extractTitle(body)
+        const finding = extractFinding(body)
+        const summary = [
+          `Visited ${targetUrl} and observed title "${title || "unknown"}".`,
+          finding ? `Detected finding "${finding}".` : `No finding marker detected.`,
+        ].join(" ")
+
+        return ndjson([
+          {
+            jsonrpc: "2.0",
+            method: "session/update",
+            params: {
+              sessionId,
+              update: {
+                content: {
+                  text: summary,
+                  type: "text",
+                },
+                sessionUpdate: "agent_message_chunk",
+              },
+            },
+          },
+          makeResult(id, {
+            stopReason: "end_turn",
+          }),
+        ])
+      }
+
+      return ndjson([makeError(id, -32601, "Method not found")])
+    },
+    run(args: string[]) {
+      console.log("test slot app")
+      console.log(`args: ${JSON.stringify(args)}`)
+    },
+  }
+}
+
+const app = createTestSlotApp()
+
+export default {
+  fetch(req: Request) {
+    return app.fetch(req)
+  },
+  run(args: string[]) {
+    return app.run(args)
+  },
+}

--- a/.smallweb-root/test-slot/main_test.ts
+++ b/.smallweb-root/test-slot/main_test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict"
+
+import { createRangeFixtureApp } from "../range-fixture/main.ts"
+import { createTestSlotApp } from "./main.ts"
+
+async function readNdjson(response: Response) {
+  const body = await response.text()
+
+  return body
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+}
+
+function createRouterFetch(routes: Record<string, { fetch(req: Request): Response | Promise<Response> }>) {
+  const fetchImpl = async (target: string | URL | Request, init?: RequestInit) => {
+    const request = target instanceof Request ? target : new Request(String(target), init)
+    const url = new URL(request.url)
+    const app = routes[url.host]
+
+    if (!app) {
+      throw new Error(`Unexpected routed host: ${url.host}`)
+    }
+
+    return await app.fetch(request)
+  }
+
+  return fetchImpl
+}
+
+Deno.test("test-slot ACP flow fetches the range fixture and summarizes the finding", async () => {
+  const rangeFixture = createRangeFixtureApp()
+  const testSlot = createTestSlotApp({
+    fetchImpl: createRouterFetch({
+      "fixture.test": rangeFixture,
+    }),
+  })
+
+  const initialize = await readNdjson(await testSlot.fetch(new Request("https://slot.tidelands.dev/acp", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      id: 0,
+      jsonrpc: "2.0",
+      method: "initialize",
+      params: {
+        protocolVersion: 1,
+      },
+    }),
+  })))
+  assert.equal(initialize[0].result.protocolVersion, 1)
+
+  const sessionNew = await readNdjson(await testSlot.fetch(new Request("https://slot.tidelands.dev/acp", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      id: 1,
+      jsonrpc: "2.0",
+      method: "session/new",
+      params: {
+        cwd: "/tmp/test-slot",
+        mcpServers: [],
+      },
+    }),
+  })))
+  const sessionId = sessionNew[0].result.sessionId
+  assert.match(sessionId, /^slot_/)
+
+  const prompt = await readNdjson(await testSlot.fetch(new Request("https://slot.tidelands.dev/acp", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      id: 2,
+      jsonrpc: "2.0",
+      method: "session/prompt",
+      params: {
+        prompt: [
+          {
+            text: "Target URL: https://fixture.test/recon?q=alpha&finding=known-vuln",
+            type: "text",
+          },
+        ],
+        sessionId,
+      },
+    }),
+  })))
+  const summary = prompt[0].params.update.content.text
+
+  assert.match(summary, /Fixture Target/)
+  assert.match(summary, /Detected finding "known-vuln"/)
+  assert.equal(prompt[1].result.stopReason, "end_turn")
+})

--- a/.smallweb-root/test-slot/smallweb.json
+++ b/.smallweb-root/test-slot/smallweb.json
@@ -1,0 +1,6 @@
+{
+  "publicRoutes": [
+    "/acp",
+    "/healthz"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a minimal `test-slot` ACP app and deterministic `range-fixture` target app to the Smallweb root
- teach the admin conductor about `mode=test` slots and simple oracle scoring via `oracle.expectedSubstrings`
- replace the admin test harness’s fake downstream persona stub with real routed app-to-app ACP and target execution

## Testing
- `/workspaces/null-hype.github.io/.deno-runtime/bin/deno test -A --no-check .smallweb-root/range-fixture/main_test.ts .smallweb-root/test-slot/main_test.ts .smallweb-root/admin/main_test.ts .smallweb-root/linear-agent/main_test.ts`

## Notes
- stacked on top of `plan-394`
- this is the first concrete `PLAN-398` loop: one test-mode slot, one deterministic target, one oracle, same admin conductor